### PR TITLE
Fixes ignored Hugo versions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,9 @@
   command = "npm run build"
   publish = "dist"
   
-[template.environment]
-  HUGO_VERSION = "0.26"
+[context.production.environment]
+  HUGO_VERSION = "0.29"
 
-[context.deploy-preview]
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.29"
   command = "npm run build-preview"


### PR DESCRIPTION
Looks like old Netlify environment paths.

Not sure if this will fix the issue when it is one click deployed, but the HUGO versions are not set using your environment paths.

I bumped my version to 0.29 and it worked just fine also.

[Reference](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/)