### PR TITLE
Fixed environment vars and commands

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,15 @@
 [build]
   command = "npm run build"
   publish = "dist"
+
+[context.deploy-preview]
+  command = "npm run build-preview"
   
 [context.production.environment]
   HUGO_VERSION = "0.29"
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.29"
-  command = "npm run build-preview"
+
+[context.branch-deploy.environment]
+  HUGO_VERSION = "0.29"  


### PR DESCRIPTION
Sorry Brian @bdougie , I pulled the trigger too early yesterday and gacked the deploy-preview context command.
Also, I was bit by the branch deploy without a global set on `HUGO_VERSION` and Netlify reverts back to 0.17 of HUGO

This fixes that problem:
Added branch-deploy environment var in the case someone wants to branch test

Let me know if you need me to change anything or add comments to the lines.